### PR TITLE
return 변수명 변경( 겹쳐서 버그 발생 )

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
     var config = null
     var iamportUrl = 'https://cdn.iamport.kr/js/iamport.payment-1.1.7.js'
 
-    var IMP = {
+    var self = {
         install: function(Vue, options) {
             Vue.IMP = IMP
             Vue.prototype.$IMP = IMP
@@ -88,5 +88,5 @@
         })
     }
 
-    return IMP
+    return self;
 }))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33514304/54612362-2bb2c300-4a9c-11e9-81d2-db28877515cf.png)


변경후 정상적으로 load 함수가 정의됨을 알 수 있습니다.
```
console.log(Vue.IMP().load);
```
![image](https://user-images.githubusercontent.com/33514304/54612468-5866da80-4a9c-11e9-885e-774b65906b43.png)
